### PR TITLE
Fix typo in readme causing example script to fail.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ var umd = new UMD(5001);
 
 umd.on('message', function(tally) {
 	console.log("Tally update:", tally);
-);
+});
 ```
 
 ### Tested OK with


### PR DESCRIPTION
The example given in the Readme.md file was missing a closing bracket.